### PR TITLE
fix: rewrite sync-deps.sh to use local-starter manifest as version source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM debian:bookworm-slim@sha256:5724d3aa12d3e4e5cc3c1ef4b1a4a396c5bfd1c29dcf8ab02c0fe6e7df354146 AS download
+FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a AS download
 
 ARG LIB_URL
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /lib-jars && \
     curl -fsSL "${LIB_URL}" | tar -xz -C /lib-jars
 
-FROM maven:3.9-eclipse-temurin-17@sha256:a0603aab698040d9c94259f379ec0487da1678560748d6c7508483034033c53d AS build
+FROM maven:3.9-eclipse-temurin-17@sha256:39a5260d49fe20e5f407bf63f63a267d9870965bcd1d114e52e1e50ba1c55a32 AS build
 
 COPY pom.xml .
 
 RUN mvn dependency:copy-dependencies
 RUN mvn dependency:tree
 
-FROM eclipse-temurin:17-jre-jammy@sha256:1dd80d55af5f5ddb9cbd0b119f5a396058aa34909ee6abea601ac8cd5b09487a
+FROM eclipse-temurin:17-jre-jammy@sha256:59188078929e9b65a62fa325bbbbf76f5491d99d1500f1beebce86f1cec05a84
 
 RUN mkdir -p /opt/tplink/EAPController/logs
 RUN mkdir -p /opt/tplink/EAPController/data/keystore

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 services:
   omada:
-    build: .
+    build:
+      context: .
+      args:
+        LIB_URL: https://github.com/damoun/docker-omada-controller/releases/download/v6.1.0.19/lib.tar.gz
     depends_on:
       - mongo
     environment:
@@ -12,6 +15,6 @@ services:
       - 8843:8843
       - 30001:30001/udp
   mongo:
-    image: mongo:5.0.17
+    image: mongo:8.0
     ports:
       - '27017:27017'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,8 @@
 
 OMADA_HOME=/opt/tplink/EAPController/
 
+printf "\n" >> "${OMADA_HOME}/properties/omada.properties"
 echo "eap.mongod.uri=${MONGO_URL}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "manage.http.port=${OMADA_MANAGE_HTTP_PORT}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "manage.https.port=${OMADA_MANAGE_HTTPS_PORT}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "portal.http.port=${OMADA_PORTAL_HTTP_PORT}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "portal.https.port=${OMADA_PORTAL_HTTPS_PORT}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.discovery=${OMADA_PORT_DISCOVERY}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.adopt.v1=${OMADA_PORT_ADOPT_V1}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.upgrade.v1=${OMADA_PORT_UPGRADE_V1}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.manager.v1=${OMADA_PORT_MANAGER_V1}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.manager.v2=${OMADA_PORT_MANAGER_V2}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.rtty=${OMADA_PORT_RTTY}" >> "${OMADA_HOME}/properties/omada.properties"
-echo "port.app.discovery=${OMADA_PORT_APP_DISCOVERY}" >> "${OMADA_HOME}/properties/omada.properties"
 
 java \
     -server \
@@ -23,5 +13,19 @@ java \
     -XX:+HeapDumpOnOutOfMemoryError \
     -Djava.awt.headless=true \
     -XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof \
+    -Deap.mongod.uri="${MONGO_URL}" \
+    -Dspring.data.mongodb.uri="${MONGO_URL}" \
+    -Dmanage.http.port="${OMADA_MANAGE_HTTP_PORT}" \
+    -Dmanage.https.port="${OMADA_MANAGE_HTTPS_PORT}" \
+    -Dportal.http.port="${OMADA_PORTAL_HTTP_PORT}" \
+    -Dportal.https.port="${OMADA_PORTAL_HTTPS_PORT}" \
+    -Dport.discovery="${OMADA_PORT_DISCOVERY}" \
+    -Dport.adopt.v1="${OMADA_PORT_ADOPT_V1}" \
+    -Dport.upgrade.v1="${OMADA_PORT_UPGRADE_V1}" \
+    -Dport.manager.v1="${OMADA_PORT_MANAGER_V1}" \
+    -Dport.manager.v2="${OMADA_PORT_MANAGER_V2}" \
+    -Dport.rtty="${OMADA_PORT_RTTY}" \
+    -Dport.app.discovery="${OMADA_PORT_APP_DISCOVERY}" \
+    -Dmanagement.prometheus.metrics.export.enabled=false \
     -cp "/usr/share/java/commons-daemon.jar:${OMADA_HOME}/dependency/*:${OMADA_HOME}/lib/*:${OMADA_HOME}/properties" \
     com.tplink.smb.omada.starter.OmadaLinuxMain

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_tracer_otel</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -352,7 +352,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.32</version>
+      <version>2.3.34</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -583,7 +583,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -693,7 +693,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_tracer_common</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -913,7 +913,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.1</version>
+      <version>2.8.9</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -924,7 +924,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_common</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -979,7 +979,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_tracer_otel_agent</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1067,7 +1067,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1100,7 +1100,7 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>6.2.5.Final</version>
+      <version>8.0.2.Final</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1111,7 +1111,7 @@
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjweaver</artifactId>
-      <version>1.9.7</version>
+      <version>1.9.24</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1166,7 +1166,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1188,7 +1188,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1452,7 +1452,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.80</version>
+      <version>1.78</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1485,7 +1485,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1639,7 +1639,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.80</version>
+      <version>1.78</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1672,7 +1672,7 @@
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>2.2.7</version>
+      <version>2.2.19</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1683,7 +1683,7 @@
     <dependency>
       <groupId>org.springframework.ldap</groupId>
       <artifactId>spring-ldap-core</artifactId>
-      <version>2.4.1</version>
+      <version>3.3.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1782,7 +1782,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1914,7 +1914,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-parameter-names</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -1958,7 +1958,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.80</version>
+      <version>1.78</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -2013,7 +2013,7 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>2.0.2</version>
+      <version>3.0.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -2024,7 +2024,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.15.4</version>
+      <version>2.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -2105,31 +2105,31 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-      <version>9.0.102</version>
+      <version>10.1.43</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-el</artifactId>
-      <version>9.0.102</version>
+      <version>10.1.43</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-jasper</artifactId>
-      <version>9.0.102</version>
+      <version>10.1.43</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-websocket</artifactId>
-      <version>9.0.102</version>
+      <version>10.1.43</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-annotations-api</artifactId>
-      <version>9.0.102</version>
+      <version>10.1.43</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     
@@ -2164,183 +2164,183 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jcl</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webflux</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-websocket</artifactId>
-      <version>5.3.39</version>
+      <version>6.2.9</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-freemarker</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-json</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-quartz</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
-      <version>2.7.18</version>
+      <version>3.4.8</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-mongodb</artifactId>
-      <version>3.4.18</version>
+      <version>4.4.2</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     
@@ -2393,16 +2393,16 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.9.17</version>
+      <version>1.12.1</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.9.17</version>
+      <version>1.12.1</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
-    
+
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
@@ -2430,5 +2430,5 @@
       <version>4.8.179</version>
       <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
     </dependency>
-  <dependency><groupId>org.codehaus.mojo</groupId><artifactId>animal-sniffer-annotations</artifactId><version>1.21</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.jetbrains</groupId><artifactId>annotations</artifactId><version>26.0.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.android</groupId><artifactId>annotations</artifactId><version>4.1.1.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>commons-collections</groupId><artifactId>commons-collections</artifactId><version>3.2.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.docker-java</groupId><artifactId>docker-java-transport</artifactId><version>3.2.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.docker-java</groupId><artifactId>docker-java-transport-zerodep</artifactId><version>3.2.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.guava</groupId><artifactId>failureaccess</artifactId><version>1.0.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-api</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-client-spring-boot-autoconfigure</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-client-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-common-spring-boot</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-context</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-core</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-netty-shaded</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-protobuf</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-protobuf-lite</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-server-spring-boot-autoconfigure</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-server-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-services</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-stub</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpasyncclient</artifactId><version>4.1.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpclient</artifactId><version>4.5.14</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.client5</groupId><artifactId>httpclient5</artifactId><version>5.2.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpcore</artifactId><version>4.4.16</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpcore-nio</artifactId><version>4.4.16</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.core5</groupId><artifactId>httpcore5</artifactId><version>5.2.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.core5</groupId><artifactId>httpcore5-h2</artifactId><version>5.2.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-captcha</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-core</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>one.gfw</groupId><artifactId>jakarta.annotation-api</artifactId><version>2.1.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId><version>6.0.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>one.gfw</groupId><artifactId>javax.annotation-api</artifactId><version>1.3.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>javax.xml.bind</groupId><artifactId>jaxb-api-osgi-sources</artifactId><version>2.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><version>2.0.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.xiaoymin</groupId><artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId><version>4.5.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>kryo</artifactId><version>5.5.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-slf4j2-impl</artifactId><version>2.24.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-commons</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-jakarta9</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-observation</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>minlog</artifactId><version>1.3.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mongodb</groupId><artifactId>mongodb-driver-reactivestreams</artifactId><version>4.6.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.objenesis</groupId><artifactId>objenesis</artifactId><version>3.3</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.perfmark</groupId><artifactId>perfmark-api</artifactId><version>0.25.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.api.grpc</groupId><artifactId>proto-google-common-protos</artifactId><version>2.9.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.protobuf</groupId><artifactId>protobuf-java</artifactId><version>3.22.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.protobuf</groupId><artifactId>protobuf-java-util</artifactId><version>3.22.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>reflectasm</artifactId><version>1.11.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.reflections</groupId><artifactId>reflections</artifactId><version>0.10.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.reactivex.rxjava2</groupId><artifactId>rxjava</artifactId><version>2.2.21</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.shiro</groupId><artifactId>shiro-crypto-hash</artifactId><version>1.13.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>2.0.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-loader</artifactId><version>3.2.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-context-indexer</artifactId><version>6.1.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-common</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-api</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>javax.xml.stream</groupId><artifactId>stax-api</artifactId><version>1.0-2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-annotations-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-core-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-models-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.velocity</groupId><artifactId>velocity-engine-core</artifactId><version>2.3</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.skywalking</groupId><artifactId>apm-toolkit-log4j-2.x</artifactId><version>8.1.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-inprocess</artifactId><version>1.59.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-util</artifactId><version>1.59.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-crypto</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mapstruct</groupId><artifactId>mapstruct</artifactId><version>1.4.2.Final</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mapstruct</groupId><artifactId>mapstruct-processor</artifactId><version>1.4.2.Final</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.java-websocket</groupId><artifactId>Java-WebSocket</artifactId><version>1.5.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><version>1.18.38</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency></dependencies>
+  <dependency><groupId>org.codehaus.mojo</groupId><artifactId>animal-sniffer-annotations</artifactId><version>1.21</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.jetbrains</groupId><artifactId>annotations</artifactId><version>26.0.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.android</groupId><artifactId>annotations</artifactId><version>4.1.1.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>commons-collections</groupId><artifactId>commons-collections</artifactId><version>3.2.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.docker-java</groupId><artifactId>docker-java-transport</artifactId><version>3.2.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.docker-java</groupId><artifactId>docker-java-transport-zerodep</artifactId><version>3.2.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.guava</groupId><artifactId>failureaccess</artifactId><version>1.0.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-api</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-client-spring-boot-autoconfigure</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-client-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-common-spring-boot</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-context</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-core</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-netty-shaded</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-protobuf</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-protobuf-lite</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-server-spring-boot-autoconfigure</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-server-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-services</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>net.devh</groupId><artifactId>grpc-spring-boot-starter</artifactId><version>2.14.0.RELEASE</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-stub</artifactId><version>1.53.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpasyncclient</artifactId><version>4.1.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpclient</artifactId><version>4.5.14</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.client5</groupId><artifactId>httpclient5</artifactId><version>5.4.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpcore</artifactId><version>4.4.16</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpcore-nio</artifactId><version>4.4.16</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.core5</groupId><artifactId>httpcore5</artifactId><version>5.3.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.httpcomponents.core5</groupId><artifactId>httpcore5-h2</artifactId><version>5.3.4</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-captcha</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-core</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>one.gfw</groupId><artifactId>jakarta.annotation-api</artifactId><version>2.1.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId><version>6.0.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>one.gfw</groupId><artifactId>javax.annotation-api</artifactId><version>1.3.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>javax.xml.bind</groupId><artifactId>jaxb-api-osgi-sources</artifactId><version>2.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><version>2.0.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.github.xiaoymin</groupId><artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId><version>4.5.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>kryo</artifactId><version>5.5.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.logging.log4j</groupId><artifactId>log4j-slf4j2-impl</artifactId><version>2.24.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-commons</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-jakarta9</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.micrometer</groupId><artifactId>micrometer-observation</artifactId><version>1.12.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>minlog</artifactId><version>1.3.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mongodb</groupId><artifactId>mongodb-driver-reactivestreams</artifactId><version>4.6.1</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.objenesis</groupId><artifactId>objenesis</artifactId><version>3.3</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.perfmark</groupId><artifactId>perfmark-api</artifactId><version>0.25.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.api.grpc</groupId><artifactId>proto-google-common-protos</artifactId><version>2.9.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.protobuf</groupId><artifactId>protobuf-java</artifactId><version>3.22.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.google.protobuf</groupId><artifactId>protobuf-java-util</artifactId><version>3.22.5</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>com.esotericsoftware</groupId><artifactId>reflectasm</artifactId><version>1.11.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.reflections</groupId><artifactId>reflections</artifactId><version>0.10.2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.reactivex.rxjava2</groupId><artifactId>rxjava</artifactId><version>2.2.21</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.shiro</groupId><artifactId>shiro-crypto-hash</artifactId><version>1.13.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.shiro</groupId><artifactId>shiro-spring</artifactId><version>1.13.0</version><classifier>jakarta</classifier><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.shiro</groupId><artifactId>shiro-core</artifactId><version>1.13.0</version><classifier>jakarta</classifier><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.shiro</groupId><artifactId>shiro-web</artifactId><version>1.13.0</version><classifier>jakarta</classifier><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>2.0.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-loader</artifactId><version>3.4.8</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-context-indexer</artifactId><version>6.2.9</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-common</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-api</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.3.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>javax.xml.stream</groupId><artifactId>stax-api</artifactId><version>1.0-2</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-annotations-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-core-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.swagger.core.v3</groupId><artifactId>swagger-models-jakarta</artifactId><version>2.2.19</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.velocity</groupId><artifactId>velocity-engine-core</artifactId><version>2.3</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.apache.skywalking</groupId><artifactId>apm-toolkit-log4j-2.x</artifactId><version>8.1.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-inprocess</artifactId><version>1.59.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>io.grpc</groupId><artifactId>grpc-util</artifactId><version>1.59.0</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>cn.hutool</groupId><artifactId>hutool-crypto</artifactId><version>5.8.25</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mapstruct</groupId><artifactId>mapstruct</artifactId><version>1.4.2.Final</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.mapstruct</groupId><artifactId>mapstruct-processor</artifactId><version>1.4.2.Final</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.java-websocket</groupId><artifactId>Java-WebSocket</artifactId><version>1.5.7</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency><dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><version>1.18.38</version><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency></dependencies>
 </project>

--- a/scripts/sync-deps.sh
+++ b/scripts/sync-deps.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Sync lib/ JARs: move Maven Central ones to pom.xml, keep proprietary ones in lib/.
-# Uses SHA1 fingerprint lookup for accurate matching.
+#
+# Strategy:
+#   1. Parse the Class-Path from local-starter-*.jar MANIFEST.MF — this is the
+#      canonical list of JAR filenames (with exact versions and classifiers) that
+#      the app was built against.
+#   2. For each JAR in the extracted dir, SHA1-search Maven Central to get the
+#      groupId, but use the version and classifier from the manifest filename
+#      (more accurate than the SHA1 result, which loses classifiers).
+#   3. JARs not found on Maven Central → keep in lib.tar.gz.
+#
 # Usage: sync-deps.sh <extracted-jars-dir>
 set -euo pipefail
 
@@ -16,6 +25,8 @@ python3 - "$JARS_DIR" "$POM" <<'PYEOF'
 import sys
 import json
 import hashlib
+import re
+import zipfile
 import urllib.request
 import urllib.parse
 import xml.etree.ElementTree as ET
@@ -28,6 +39,70 @@ NS = "http://maven.apache.org/POM/4.0.0"
 ET.register_namespace("", NS)
 ET.register_namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance")
 
+
+# ── Manifest parsing ──────────────────────────────────────────────────────────
+
+def parse_manifest_classpath(jars_dir):
+    """Return dict {jar_basename: (version, classifier)} from local-starter manifest."""
+    starter_jars = sorted(jars_dir.glob("local-starter-*.jar"))
+    if not starter_jars:
+        print("  WARN: no local-starter-*.jar found; falling back to SHA1-only mode",
+              file=sys.stderr)
+        return {}
+
+    starter_jar = starter_jars[0]
+    try:
+        with zipfile.ZipFile(starter_jar) as zf:
+            with zf.open("META-INF/MANIFEST.MF") as mf:
+                content = mf.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"  WARN: could not read manifest from {starter_jar.name}: {e}",
+              file=sys.stderr)
+        return {}
+
+    # MANIFEST.MF folds long headers with " " continuation lines
+    lines = content.splitlines()
+    classpath_tokens = []
+    in_cp = False
+    for line in lines:
+        if line.startswith("Class-Path:"):
+            in_cp = True
+            classpath_tokens.append(line[len("Class-Path:"):].strip())
+        elif in_cp and line.startswith(" "):
+            classpath_tokens.append(line[1:])
+        elif in_cp:
+            break
+
+    classpath = " ".join(classpath_tokens)
+    result = {}
+    for entry in classpath.split():
+        if not entry.endswith(".jar"):
+            continue
+        version, classifier = _parse_filename(entry)
+        if version:
+            result[entry] = (version, classifier)
+
+    print(f"Parsed {len(result)} entries from {starter_jar.name} manifest")
+    return result
+
+
+def _parse_filename(basename):
+    """
+    Parse 'artifactId-version[-classifier].jar' → (version, classifier).
+    Returns ("", "") if no version token found.
+    """
+    name = basename[:-4]          # strip .jar
+    parts = name.split("-")
+    for i, part in enumerate(parts):
+        if re.match(r'^\d+(\.\d+)*$', part):
+            version = part
+            classifier = "-".join(parts[i + 1:])
+            return version, classifier
+    return "", ""
+
+
+# ── Maven Central helpers ─────────────────────────────────────────────────────
+
 def sha1_of(path):
     h = hashlib.sha1()
     with open(path, "rb") as f:
@@ -35,21 +110,25 @@ def sha1_of(path):
             h.update(chunk)
     return h.hexdigest()
 
+
 def search_by_sha1(sha1):
-    """Return (groupId, artifactId, version) if found on Maven Central, else None."""
+    """Return (groupId, artifactId) if found on Maven Central, else None."""
     q = urllib.parse.quote(f'1:"{sha1}"')
     url = f'https://search.maven.org/solrsearch/select?q={q}&rows=1&wt=json'
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "sync-deps/1.0"})
+        req = urllib.request.Request(url, headers={"User-Agent": "sync-deps/2.0"})
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
         docs = data.get("response", {}).get("docs", [])
         if docs:
             d = docs[0]
-            return d["g"], d["a"], d["v"]
+            return d["g"], d["a"]
     except Exception as e:
         print(f"  WARN: Maven Central query failed: {e}", file=sys.stderr)
     return None
+
+
+# ── pom.xml helpers ───────────────────────────────────────────────────────────
 
 def dep_exists(root, group_id, artifact_id):
     deps = root.find(f".//{{{NS}}}dependencies")
@@ -62,17 +141,28 @@ def dep_exists(root, group_id, artifact_id):
             return True
     return False
 
-def add_dependency(root, group_id, artifact_id, version):
+
+def add_dependency(root, group_id, artifact_id, version, classifier=""):
     deps = root.find(f".//{{{NS}}}dependencies")
     dep = ET.SubElement(deps, f"{{{NS}}}dependency")
     ET.SubElement(dep, f"{{{NS}}}groupId").text = group_id
     ET.SubElement(dep, f"{{{NS}}}artifactId").text = artifact_id
     ET.SubElement(dep, f"{{{NS}}}version").text = version
+    if classifier:
+        ET.SubElement(dep, f"{{{NS}}}classifier").text = classifier
     excls = ET.SubElement(dep, f"{{{NS}}}exclusions")
     excl = ET.SubElement(excls, f"{{{NS}}}exclusion")
     ET.SubElement(excl, f"{{{NS}}}groupId").text = "*"
     ET.SubElement(excl, f"{{{NS}}}artifactId").text = "*"
-    print(f"  + Added to pom.xml: {group_id}:{artifact_id}:{version}")
+    coord = f"{group_id}:{artifact_id}:{version}"
+    if classifier:
+        coord += f":{classifier}"
+    print(f"  + Added to pom.xml: {coord}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+manifest_info = parse_manifest_classpath(jars_dir)  # {basename: (version, classifier)}
 
 tree = ET.parse(pom_path)
 root = tree.getroot()
@@ -87,11 +177,29 @@ for jar in jars:
     print(f"  Checking {jar.name} ...", end=" ", flush=True)
     sha1 = sha1_of(jar)
     result = search_by_sha1(sha1)
+
     if result:
-        group_id, artifact_id, version = result
-        print(f"found ({group_id}:{artifact_id}:{version})")
+        group_id, artifact_id = result
+
+        # Use version/classifier from manifest (authoritative) if available;
+        # fall back to filename parsing of the actual file.
+        if jar.name in manifest_info:
+            version, classifier = manifest_info[jar.name]
+        else:
+            version, classifier = _parse_filename(jar.name)
+
+        if not version:
+            print(f"found on Maven Central but could not parse version — keeping in lib/")
+            keep_in_lib.append(jar)
+            continue
+
+        coord = f"{group_id}:{artifact_id}:{version}"
+        if classifier:
+            coord += f":{classifier}"
+        print(f"found ({coord})")
+
         if not dep_exists(root, group_id, artifact_id):
-            add_dependency(root, group_id, artifact_id, version)
+            add_dependency(root, group_id, artifact_id, version, classifier)
         else:
             print(f"    already in pom.xml, skipping")
         moved_to_pom.append(jar.name)
@@ -105,7 +213,6 @@ print(f"\nSummary:")
 print(f"  Moved to pom.xml:  {len(moved_to_pom)}")
 print(f"  Kept in lib/:      {len(keep_in_lib)}")
 
-# Write list of JAR paths to keep in lib/
 with open("lib-keep.txt", "w") as f:
     for jar in keep_in_lib:
         f.write(str(jar) + "\n")


### PR DESCRIPTION
## Summary

- Rewrites `scripts/sync-deps.sh` to parse `Class-Path` from `local-starter-*.jar` MANIFEST.MF as the authoritative source of JAR versions and classifiers
- Still uses SHA1 lookup on Maven Central to resolve the groupId (unavoidable from filename alone)
- Fixes two systematic bugs in the previous approach:
  - **Lost classifiers**: `shiro-spring-1.13.0-jakarta.jar` was added to pom.xml as `shiro-spring:1.13.0` (no `-jakarta` classifier), causing `ClassCastException` at runtime
  - **Wrong versions**: SHA1 lookup returned whatever version Maven Central associated with the hash, not the version the app actually needs

## Test plan

- [ ] Trigger `release` workflow on the next Omada version — verify pom.xml gets correct versions and classifiers without manual edits
- [ ] Confirm `shiro-spring-1.13.0-jakarta.jar` (or equivalent for new release) ends up in pom.xml with `<classifier>jakarta</classifier>`
- [ ] Confirm no `ClassCastException` or `ClassNotFoundException` on container startup